### PR TITLE
Fix URL to downloaded .jar file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -135,7 +135,7 @@
 
         <mkdir dir="${ivy.jar.dir}"/>
         <!-- download Ivy from web site so that it can be used even without any special installation -->
-        <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" 
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
              dest="${ivy.jar.file}" usetimestamp="true"/>
     </target>
 


### PR DESCRIPTION
The URL currently present results in the following error:
```
BUILD FAILED
APIServerDaemon/build.xml:139: java.net.UnknownHostException: repo2.maven.org
```